### PR TITLE
Typo in specification of Presets folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ use conquer\codemirror\CodemirrorWidget;
 $form->field($model, 'code')->widget(
     CodemirrorWidget::className(),
     [
-        'presetDir'=>'/path_to_your_presets',
+        'presetsDir'=>'/path_to_your_presets',
         'preset'=>'sql',
     ]
 );


### PR DESCRIPTION
There was an error in the example of how to specify the presets folder