### PR TITLE
Use JS position POS_READY instead of POS_END

### DIFF
--- a/CodemirrorWidget.php
+++ b/CodemirrorWidget.php
@@ -63,7 +63,7 @@ class CodemirrorWidget extends \yii\widgets\InputWidget
         $settings = Json::encode($settings);
         $instanceName = 'CM_'.preg_replace('/[^\w\d]/ius', '', $id);
         $js = "CodeMirror.fromTextArea(document.getElementById('$id'), $settings);";
-        $view->registerJs($js, $view::POS_END);
+        $view->registerJs($js, $view::POS_READY);
         CodemirrorAsset::register($this->view, $assets);
     }
 


### PR DESCRIPTION
This PR fixes a problem of when the client side code tries to access the code mirror instance. The problem seems to only exist when using multiple instances of the widget.

POS_READY simply wraps the init code in jQuery.ready()